### PR TITLE
Fixed ImageInfo Fullname and Mustache Template

### DIFF
--- a/compass-imagehelper.mustache
+++ b/compass-imagehelper.mustache
@@ -43,7 +43,7 @@
   // The third argument is used to control the cache buster on a per-use basis. When set to false no cache buster will be used.
   // When true a md5-hash of the file is appended to the url. When a string, that value will be used as the cache buster.
   @function image-url($image, $only-path: false, $cache-buster: false) {
-    $result: "../images/" + $image;
+    $result: "{{{path_prefix}}}" + $image;
 
     @if ($cache-buster == true) {
       @if not (image-exists($image)) {

--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@ module.exports = function (options) {
         imageInfo.dirname = path.basename(path.dirname(file.path));
         imageInfo.ext = path.extname(file.path);
         imageInfo.path = path.relative(options.images_path, file.path);
-        imageInfo.fullname = imageInfo.path.split('/').join('-').path.split('\\').join('-').replace('.', '-');
+        // Replace /, \ and . with -
+        imageInfo.fullname = imageInfo.path.replace(/[\/\\\.]/g, '-');
         imageInfo.hash = md5(file.contents);
         imageInfo.data = 'url(data:' + mimetype + ';' + encoding + ',' + data + ')';
         images.push(imageInfo);


### PR DESCRIPTION
Hi,

I have fixed an issue with the fullname generate which caused an error as .path is called where it is not available and make use of a single regex to replace the characters `/`, `\` and `.` with `-`.

I also added the path_prefix to the default Mustache Template as this never used the generated path_info.

Cheers,
Niklas
